### PR TITLE
Support macOS Packed Structs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @t0rr3sp3dr0 @tonidas


### PR DESCRIPTION
Due to pack pragma on [`krb5.h`](https://github.com/krb5/krb5/blob/master/src/include/krb5/krb5.hin#L109) that is only used on macOS, some struct fields are not accessible from Go directly.

```c
#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
#    pragma pack(push,2)
#endif
```

In these cases is necessary to use an auxiliary function to get/set those fields.

Fixes golang/go#35640